### PR TITLE
Update Offline Mode to Support Jetpack 8.8+

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors:      tannerm
 Tags:              jetpack
 Requires at least: 3.5.1
-Tested up to:      4.0.0
-Stable tag:        0.1.0
+Tested up to:      5.5
+Stable tag:        1.0.0
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -31,6 +31,9 @@ If you find that the module you are interested in is not available after install
 
 
 == Changelog ==
+
+= 1.0.0 =
+* Replaced `jetpack_development_mode` hook with `jetpack_offline_mode` to support Jetpack versions 8.8+
 
 = 0.1.0 =
 * First release

--- a/unplug-jetpack.php
+++ b/unplug-jetpack.php
@@ -3,14 +3,14 @@
  * Plugin Name: Unplug Jetpack
  * Plugin URI:  http://wordpress.org/extend/plugins
  * Description: Enable qualifying Jetpack modules without a WordPress.com account
- * Version:     0.1.0
+ * Version:     1.0.0
  * Author:      Tanner Moushey
  * Author URI:  tannermoushey.com
  * License:     GPLv2+
  */
 
 /**
- * Copyright (c) 2014 Tanner Moushey (email : tanner@iwitnessdesign.com)
+ * Copyright (c) 2020 Tanner Moushey (email : tanner@missionlab.dev)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License, version 2 or, at
@@ -28,6 +28,6 @@
  */
 
 function uj_init() {
-	add_filter( 'jetpack_development_mode', '__return_true' );
+	add_filter( 'jetpack_offline_mode', '__return_true' );
 }
 add_action( 'plugins_loaded', 'uj_init' );


### PR DESCRIPTION
Replaced jetpack_development_mode hook with jetpack_offline_mode hook to support Jetpack versions 8.8+. Updated plugin readme and versions.